### PR TITLE
Add support for "none" attestation format

### DIFF
--- a/packages/server/src/authenticatorKey/index.js
+++ b/packages/server/src/authenticatorKey/index.js
@@ -2,6 +2,7 @@ const { decodeAllSync } = require('cbor');
 const { parseAndroidSafetyNetKey } = require('./parseAndroidSafetyNetKey');
 const { parseFidoU2FKey } = require('./parseFidoU2FKey');
 const { parseFidoPackedKey } = require('./parseFidoPackedKey');
+const { parseNoneKey } = require('./parseNoneKey');
 
 exports.getAuthenticatorKeyId = key_id => {
     const buffer = Buffer.from(key_id, 'base64');
@@ -19,6 +20,10 @@ exports.parseAuthenticatorKey = async (credentials) => {
 
     if (authenticatorKey.fmt === 'fido-u2f') {
         return parseFidoU2FKey(authenticatorKey, credentials.clientDataJSON);
+    }
+
+    if (authenticatorKey.fmt === 'none') {
+        return parseNoneKey(authenticatorKey, credentials.clientDataJSON);
     }
 
     if (authenticatorKey.fmt === 'packed') {

--- a/packages/server/src/authenticatorKey/parseNoneKey.js
+++ b/packages/server/src/authenticatorKey/parseNoneKey.js
@@ -1,0 +1,99 @@
+const {
+    hash,
+    convertASN1toPEM,
+    verifySignature,
+    convertCOSEPublicKeyToRawPKCSECDHAKey,
+  } = require('../utils');
+
+  exports.parseNoneKey = (authenticatorKey, clientDataJSON) => {
+    const authenticatorData = parseAttestationData(authenticatorKey.authData);
+
+    if (!authenticatorData.flags.up) {
+        throw new Error('User was NOT presented during authentication!');
+    }
+
+    const publicKey = convertCOSEPublicKeyToRawPKCSECDHAKey(
+        authenticatorData.COSEPublicKey
+    );
+
+    return {
+        fmt: 'none',
+        publicKey: publicKey.toString('base64'),
+        counter: authenticatorData.counter,
+        credID: authenticatorData.credID.toString('base64'),
+    };
+  };
+
+  exports.validateNoneKey = (
+    authenticatorDataBuffer,
+    key,
+    clientDataJSON,
+    base64Signature
+  ) => {
+    const authenticatorData = parseAttestationData(authenticatorDataBuffer);
+
+    if (!authenticatorData.flags.up) {
+        throw new Error('User was NOT presented durring authentication!');
+    }
+
+    const clientDataHash = hash(
+        'SHA256',
+        Buffer.from(clientDataJSON, 'base64')
+    );
+    const signatureBase = Buffer.concat([
+        authenticatorData.rpIdHash,
+        authenticatorData.flagsBuf,
+        authenticatorData.counterBuf,
+        clientDataHash,
+    ]);
+
+    const publicKey = convertASN1toPEM(Buffer.from(key.publicKey, 'base64'));
+    const signature = Buffer.from(base64Signature, 'base64');
+
+    return verifySignature(signature, signatureBase, publicKey);
+  };
+
+  const parseAttestationData = buffer => {
+    const rpIdHash = buffer.slice(0, 32);
+    buffer = buffer.slice(32);
+    const flagsBuf = buffer.slice(0, 1);
+    buffer = buffer.slice(1);
+    const flagsInt = flagsBuf[0];
+    const flags = {
+        up: !!(flagsInt & 0x01),
+        uv: !!(flagsInt & 0x04),
+        at: !!(flagsInt & 0x40),
+        ed: !!(flagsInt & 0x80),
+        flagsInt,
+    };
+
+    const counterBuf = buffer.slice(0, 4);
+    buffer = buffer.slice(4);
+    const counter = counterBuf.readUInt32BE(0);
+
+    let aaguid;
+    let credID;
+    let COSEPublicKey;
+
+    if (flags.at) {
+        aaguid = buffer.slice(0, 16);
+        buffer = buffer.slice(16);
+        const credIDLenBuf = buffer.slice(0, 2);
+        buffer = buffer.slice(2);
+        const credIDLen = credIDLenBuf.readUInt16BE(0);
+        credID = buffer.slice(0, credIDLen);
+        buffer = buffer.slice(credIDLen);
+        COSEPublicKey = buffer;
+    }
+
+    return {
+        rpIdHash,
+        flagsBuf,
+        flags,
+        counter,
+        counterBuf,
+        aaguid,
+        credID,
+        COSEPublicKey,
+    };
+  };

--- a/packages/server/src/login.js
+++ b/packages/server/src/login.js
@@ -3,6 +3,7 @@ const { getChallengeFromClientData } = require('./getChallengeFromClientData');
 const { validateAndroidSafetyNetKey } = require('./authenticatorKey/parseAndroidSafetyNetKey');
 const { validateFidoPackedKey } = require('./authenticatorKey/parseFidoPackedKey');
 const { validateFidoU2FKey } = require('./authenticatorKey/parseFidoU2FKey');
+const { validateNoneKey } = require('./authenticatorKey/parseNoneKey');
 const { validateLoginCredentials } = require('./validation');
 
 exports.generateLoginChallenge = key => {
@@ -49,6 +50,15 @@ exports.verifyAuthenticatorAssertion = (data, key) => {
 
     if (key.fmt === 'fido-u2f') {
         return validateFidoU2FKey(
+            authenticatorDataBuffer,
+            key,
+            data.response.clientDataJSON,
+            data.response.signature
+        );
+    }
+
+    if (key.fmt === 'none') {
+        return validateNoneKey(
             authenticatorDataBuffer,
             key,
             data.response.clientDataJSON,

--- a/packages/server/src/registration.js
+++ b/packages/server/src/registration.js
@@ -5,6 +5,7 @@ const { getChallengeFromClientData } = require('./getChallengeFromClientData');
 const { parseAndroidSafetyNetKey } = require('./authenticatorKey/parseAndroidSafetyNetKey');
 const { parseFidoU2FKey } = require('./authenticatorKey/parseFidoU2FKey');
 const { parseFidoPackedKey } = require('./authenticatorKey/parseFidoPackedKey');
+const { parseNoneKey } = require('./authenticatorKey/parseNoneKey');
 const { validateRegistrationCredentials } = require('./validation');
 
 const parseAuthenticatorKey = (webAuthnResponse) => {
@@ -23,6 +24,13 @@ const parseAuthenticatorKey = (webAuthnResponse) => {
 
     if (authenticatorKey.fmt === 'fido-u2f') {
         return parseFidoU2FKey(
+            authenticatorKey,
+            webAuthnResponse.clientDataJSON
+        );
+    }
+
+    if (authenticatorKey.fmt === 'none') {
+        return parseNoneKey(
             authenticatorKey,
             webAuthnResponse.clientDataJSON
         );


### PR DESCRIPTION

## What It Does

These changes are necessary in order to support the ["none" attestation format](https://w3c.github.io/webauthn/#sctn-none-attestation) of the WebAuthn protocol. `parseNoneKey()` is very similar to the other formats, but doesn't try to verify the attestation statement (since there is none). `validate*Key()` is the same across all formats.

Part of https://banno-jha.atlassian.net/browse/NODE-388

## How To Test

No tests yet :( This works in my forthcoming branch/PR of node-consumer-login-proxy.
