### PR TITLE
build: Jenkinsfile nodejs version 10 -> 12

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -2,6 +2,6 @@ library identifier: "banno-jenkins-shared-pipelines@v1", changelog: false
 
 def version = bannoNodejsPipeline(
   githubUrl: "https://github.com/Banno/webauthn",
-  nodejsVersion: "10",
+  nodejsVersion: "12",
   slackChannel: "#auto-nodejs"
 )


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/8949910/84064503-b416cf80-a990-11ea-8f5e-1ec270d5352c.png)

https://jenkins.dev.banno-internal.com/job/node-consumer-login-proxy%20-%20veracode%20upload/1/console

i need to bump this then bump the version i'm guessing? this is choking the veracode static analysis jenkins job