### PR TITLE
dep: get rid of engine node 10 requirement

### DIFF
--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -11,9 +11,6 @@
   "scripts": {
     "lint": "eslint --fix --ignore-pattern !.eslintrc.js src"
   },
-  "engines": {
-    "node": ">=10 <11"
-  },
   "dependencies": {
     "cbor": "^5.0.1",
     "jsrsasign": "^8.0.12",


### PR DESCRIPTION
part of https://github.com/Banno/webauthn/pull/8

eric and I are going to keep an eye and see if this breaks anything. need it for veracode