### PR TITLE
Bump jsrsasign

### DIFF
--- a/example/api/index.js
+++ b/example/api/index.js
@@ -12,7 +12,7 @@ const {
     generateLoginChallenge,
     parseLoginRequest,
     verifyAuthenticatorAssertion,
-} = require('@webauthn/server');
+} = require('../../packages/server');
 
 const app = express();
 app.use(cors());

--- a/example/api/package.json
+++ b/example/api/package.json
@@ -9,7 +9,6 @@
         "dev": "nodemon -w . index.js"
     },
     "dependencies": {
-        "@webauthn/server": "^0.1.3",
         "body-parser": "^1.18.3",
         "cors": "^2.8.5",
         "express": "^4.16.4",

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -13,7 +13,7 @@
   },
   "dependencies": {
     "cbor": "^5.0.1",
-    "jsrsasign": "^8.0.12",
+    "jsrsasign": "^10.2.0",
     "jws": "^3.2.2",
     "pem": "^1.14.3"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -1617,14 +1617,6 @@
     unibabel "^2.1.7"
     webpack "^4.30.0"
 
-"@webauthn/server@^0.1.3":
-  version "0.1.3"
-  resolved "https://registry.yarnpkg.com/@webauthn/server/-/server-0.1.3.tgz#f77c0e0191ea24f5a1ecbc4835bb39370831f7cd"
-  integrity sha512-GU7E0oynSC7omaPpUMadnOd32UzUkM42JpMJbodwroAhpaX6DqT89NnPcg6tqhgNNL9jv499XS1kOBiKULOtOw==
-  dependencies:
-    cbor "^5.0.1"
-    jsrsasign "^8.0.12"
-
 "@xtuc/ieee754@^1.2.0":
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/@xtuc/ieee754/-/ieee754-1.2.0.tgz#eef014a3145ae477a1cbc00cd1e552336dceb790"
@@ -4779,11 +4771,6 @@ jsrsasign@^10.2.0:
   version "10.2.0"
   resolved "https://registry.yarnpkg.com/jsrsasign/-/jsrsasign-10.2.0.tgz#960ab8046d19d3fcbb584368a57d1977cb0b7ffd"
   integrity sha512-khMrV/10U02DRzmXhjuLQjddUF39GHndaJZ/3YiiKkbyEl1T5M6EQF9nQUq0DFVCHusmd/jl8TWl4mWt+1L5hg==
-
-jsrsasign@^8.0.12:
-  version "8.0.12"
-  resolved "https://registry.yarnpkg.com/jsrsasign/-/jsrsasign-8.0.12.tgz#22abb9656d34a30b9530436720835e89c2e5c316"
-  integrity sha1-Iqu5ZW00owuVMENnIINeicLlwxY=
 
 jwa@^1.4.1:
   version "1.4.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -4775,6 +4775,11 @@ jsprim@^1.2.2:
     json-schema "0.2.3"
     verror "1.10.0"
 
+jsrsasign@^10.2.0:
+  version "10.2.0"
+  resolved "https://registry.yarnpkg.com/jsrsasign/-/jsrsasign-10.2.0.tgz#960ab8046d19d3fcbb584368a57d1977cb0b7ffd"
+  integrity sha512-khMrV/10U02DRzmXhjuLQjddUF39GHndaJZ/3YiiKkbyEl1T5M6EQF9nQUq0DFVCHusmd/jl8TWl4mWt+1L5hg==
+
 jsrsasign@^8.0.12:
   version "8.0.12"
   resolved "https://registry.yarnpkg.com/jsrsasign/-/jsrsasign-8.0.12.tgz#22abb9656d34a30b9530436720835e89c2e5c316"


### PR DESCRIPTION

## What It Does

Upgrades the `jsrsasign` package. See https://github.com/advisories/GHSA-27fj-mc8w-j9wg.

(The `server` package is the only package that we use from this fork.)

## How To Test

The `jsrsasign` package is only used in `parseFidoPackedKey`, and I ran through the code to verify that it works.

