### PR TITLE
Add RS256 to the list of allowed key algorithms [NODE-1063]

### DIFF
--- a/packages/server/src/registration.js
+++ b/packages/server/src/registration.js
@@ -92,6 +92,10 @@ exports.generateRegistrationChallenge = ({ relyingParty, user, authenticator = '
             {
                 type: 'public-key',
                 alg: -7 // "ES256" IANA COSE Algorithms registry
+            },
+            {
+                type: 'public-key',
+                alg: -257 // "RS256" IANA COSE Algorithms registry
             }
         ],
         authenticatorSelection: {


### PR DESCRIPTION

## What It Does

Includes `RS256` in the list of public key algorithms so that devices that don't support `ES256` (e.g. Surface Pros) can still use WebAuthn.

## How To Test

Sorry, this repo has no tests. :( This will be updated in node-consumer-login-proxy and tested there.
